### PR TITLE
Update disable_cache.md

### DIFF
--- a/Drupal/8.x/disable_cache.md
+++ b/Drupal/8.x/disable_cache.md
@@ -23,6 +23,7 @@ In new file `settings.local.php` uncomment two lines:
 ```php
 $settings['cache']['bins']['render'] = 'cache.backend.null';
 $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+$settings['cache']['bins']['page'] = 'cache.backend.null';
 ```
 
 Then move null backed settings:
@@ -121,6 +122,7 @@ if (TRUE) {
   $config["system.performance"]["js"]["preprocess"] = FALSE;
   $settings["cache"]["bins"]["render"] = "cache.backend.null";
   $settings["cache"]["bins"]["dynamic_page_cache"] = "cache.backend.null";
+  $settings['cache']['bins']['page'] = 'cache.backend.null';
   $settings["extension_discovery_scan_tests"] = TRUE;
   $settings["rebuild_access"] = TRUE;
   $settings["skip_permissions_hardening"] = TRUE;


### PR DESCRIPTION
С версии 8.4 надо включать `$settings['cache']['bins']['page'] = 'cache.backend.null';` до конца не знаю для чего, но с этим параметром (точно) отключается кеш для аноноимов.